### PR TITLE
fix broken libraries link in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,7 +5,7 @@ Originally spawned in July 2021 by [Michal Ziulek](https://github.com/michal-z).
 Zero the Ziguana is an official mascot of the Zig programming language and toolchain. Licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0) https://github.com/ziglang/logo
 
 ## Vision
-- Very modular toolbox of [libraries](libraries) providing Ziggified bindings and build systems for carefully selected C and C++ libraries or written from scratch in Zig.
+- Very modular toolbox of [libraries](#libraries) providing Ziggified bindings and build systems for carefully selected C and C++ libraries or written from scratch in Zig.
 - Extensive range of [example applications](https://github.com/zig-gamedev/zig-gamedev#sample-applications-native-wgpu) that require just Zig to build and run on all popular platforms.
 
 ## Projects using zig-gamedev
@@ -19,7 +19,7 @@ Zero the Ziguana is an official mascot of the Zig programming language and toolc
 * [Pixi](https://github.com/foxnne/pixi) - Pixel art editor made with Zig.
 
 ## Dev repo
-What was the original monorepo, the [zig-gamedev dev repo](https://github.com/zig-gamedev/zig-gamedev) is the main development hub for the [libraries](libraries) and [example applications](https://github.com/zig-gamedev/zig-gamedev#sample-applications-native-wgpu).
+What was the original monorepo, the [zig-gamedev dev repo](https://github.com/zig-gamedev/zig-gamedev) is the main development hub for the [libraries](#libraries) and [example applications](https://github.com/zig-gamedev/zig-gamedev#sample-applications-native-wgpu).
 
 ## Libraries
 | Library                       | Description                                                                                                                |


### PR DESCRIPTION
this fixes `libraries` links to be a hyperlink to the "Libraries" section of the README instead of being to a nonexistent file `profile/libraries`.